### PR TITLE
Give grant_priv to root@% user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
   echo "mysqld_safe &" > /tmp/config && \
   echo "sleep 5" >> /tmp/config && \
-  echo "mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\";'" >> /tmp/config && \
+  echo "mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'" >> /tmp/config && \
   bash /tmp/config && \
   rm -f /tmp/config
 


### PR DESCRIPTION
before:

```
mysql> SELECT host,user,password,Grant_priv,Super_priv FROM mysql.user;
+--------------+------------------+-------------------------------------------+------------+------------+
| host         | user             | password                                  | Grant_priv | Super_priv |
+--------------+------------------+-------------------------------------------+------------+------------+
| localhost    | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| 95699cec7d3e | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| 127.0.0.1    | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| ::1          | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| localhost    | debian-sys-maint | *67F1EE22C865FDFF9EF25FD9F852F276CFA574EA | Y          | Y          |
| %            | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | N          | Y          |
+--------------+------------------+-------------------------------------------+------------+------------+
```

after:

```
mysql> SELECT host,user,password,Grant_priv,Super_priv FROM mysql.user;
+--------------+------------------+-------------------------------------------+------------+------------+
| host         | user             | password                                  | Grant_priv | Super_priv |
+--------------+------------------+-------------------------------------------+------------+------------+
| localhost    | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| 95699cec7d3e | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| 127.0.0.1    | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| ::1          | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
| localhost    | debian-sys-maint | *67F1EE22C865FDFF9EF25FD9F852F276CFA574EA | Y          | Y          |
| %            | root             | *C142FB215B6E05B7C134B1A653AD4B455157FD79 | Y          | Y          |
+--------------+------------------+-------------------------------------------+------------+------------+
```

without that, it's a bit tricky to add new dbs and users and grant new permission when connection through another container

e.g.

``` sh
$ docker run -t -i --rm --link my-db:db dockerfile/mysql bash -c 'mysql -h $DB_PORT_3306_TCP_ADDR'
mysql> CREATE DATABASE IF NOT EXISTS demo CHARACTER SET utf8 COLLATE utf8_general_ci;
Query OK, 1 row affected (0.00 sec)

mysql> GRANT ALL ON demo.* to 'username'@'%' IDENTIFIED BY 'password';
ERROR 1044 (42000): Access denied for user 'root'@'%' to database 'demo'
```
